### PR TITLE
Add support for arbitrary user IDs in OpenShift

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,8 +2,14 @@
 
 FROM alpine:3.18
 
-RUN apk add --no-cache --update shadow python3 py3-pip uwsgi uwsgi-python3 && \
-    pip3 install --no-cache --upgrade pip
+RUN apk add --no-cache --update bash shadow python3 py3-pip uwsgi uwsgi-python3 && \
+    pip3 install --no-cache --upgrade pip && \
+    chgrp 0 /etc/passwd && \
+    chmod g=u /etc/passwd && \
+    chgrp 0 /home && \
+    chmod g=u /home
+
+ADD entrypoint.sh /usr/local/etc/entrypoint.sh
 
 ENV SERVICE_UID=33
 ENV SERVICE_GID=33
@@ -17,10 +23,4 @@ ENV PGSERVICEFILE="/srv/pg_service.conf"
 
 STOPSIGNAL SIGINT
 
-ENTRYPOINT ["/bin/sh", "-c", "\
-    mkdir -p /home/qwc && \
-    chown $SERVICE_UID:$SERVICE_GID /home/qwc && \
-    HOME=/home/qwc uwsgi --http-socket :9090 --buffer-size $REQ_HEADER_BUFFER_SIZE --processes $UWSGI_PROCESSES \
-    --threads $UWSGI_THREADS --plugins python3 $UWSGI_EXTRA --protocol uwsgi --wsgi-disable-file-wrapper \
-    --uid $SERVICE_UID --gid $SERVICE_GID --master --chdir /srv/qwc_service --mount $SERVICE_MOUNTPOINT=server:app \
-    --manage-script-name"]
+ENTRYPOINT ["/bin/bash", "/usr/local/etc/entrypoint.sh"]

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+user_id=${SERVICE_UID:-$(id -u)}
+group_id=${SERVICE_GID:-$(id -g)}
+
+# Create passwd entry for arbitrary user ID
+if [[ -z "$(awk -F ':' "\$3 == $user_id" /etc/passwd)" ]]; then
+    echo "Adding arbitrary user"
+    echo "${USER_NAME:-default}:x:$user_id:$group_id:${USER_NAME:-default} user:/home/qwc:/sbin/nologin" \
+        >> /etc/passwd
+    echo "$(awk -F ':' "\$3 == $user_id" /etc/passwd)"
+fi
+
+echo "Running as $(id -un):$(id -gn)"
+
+# Create home directory
+mkdir -p /home/qwc
+chown $user_id:$group_id /home/qwc
+export HOME=/home/qwc
+
+uwsgi \
+  --http-socket :9090 \
+  --buffer-size $REQ_HEADER_BUFFER_SIZE \
+  --processes $UWSGI_PROCESSES \
+  --threads $UWSGI_THREADS \
+  --plugins python3 $UWSGI_EXTRA \
+  --protocol uwsgi \
+  --wsgi-disable-file-wrapper \
+  --uid $user_id \
+  --gid $group_id \
+  --master \
+  --chdir /srv/qwc_service \
+  --mount $SERVICE_MOUNTPOINT=server:app \
+  --manage-script-name

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -8,7 +8,13 @@ RUN apt-get update && apt-get install -y locales \
 ENV LANG en_US.utf8
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -qy uwsgi uwsgi-plugin-python3 python3-pip ca-certificates && \
-    pip3 install --no-cache --upgrade pip
+    pip3 install --no-cache --upgrade pip && \
+    chgrp 0 /etc/passwd && \
+    chmod g=u /etc/passwd && \
+    chgrp 0 /home && \
+    chmod g=u /home
+
+ADD entrypoint.sh /usr/local/etc/entrypoint.sh
 
 ENV SERVICE_UID=33
 ENV SERVICE_GID=33
@@ -22,10 +28,4 @@ ENV PGSERVICEFILE="/srv/pg_service.conf"
 
 STOPSIGNAL SIGINT
 
-ENTRYPOINT ["/bin/sh", "-c", "\
-    mkdir -p /home/qwc && \
-    chown $SERVICE_UID:$SERVICE_GID /home/qwc && \
-    HOME=/home/qwc uwsgi --http-socket :9090 --buffer-size $REQ_HEADER_BUFFER_SIZE --processes $UWSGI_PROCESSES \
-    --threads $UWSGI_THREADS --plugins python3 $UWSGI_EXTRA --protocol uwsgi --wsgi-disable-file-wrapper \
-    --uid $SERVICE_UID --gid $SERVICE_GID --master --chdir /srv/qwc_service --mount $SERVICE_MOUNTPOINT=server:app \
-    --manage-script-name"]
+ENTRYPOINT ["/bin/bash", "/usr/local/etc/entrypoint.sh"]

--- a/ubuntu/entrypoint.sh
+++ b/ubuntu/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+user_id=${SERVICE_UID:-$(id -u)}
+group_id=${SERVICE_GID:-$(id -g)}
+
+# Create passwd entry for arbitrary user ID
+if [[ -z "$(awk -F ':' "\$3 == $user_id" /etc/passwd)" ]]; then
+    echo "Adding arbitrary user"
+    echo "${USER_NAME:-default}:x:$user_id:$group_id:${USER_NAME:-default} user:/home/qwc:/sbin/nologin" \
+        >> /etc/passwd
+    echo "$(awk -F ':' "\$3 == $user_id" /etc/passwd)"
+fi
+
+echo "Running as $(id -un):$(id -gn)"
+
+# Create home directory
+mkdir -p /home/qwc
+chown $user_id:$group_id /home/qwc
+export HOME=/home/qwc
+
+uwsgi \
+  --http-socket :9090 \
+  --buffer-size $REQ_HEADER_BUFFER_SIZE \
+  --processes $UWSGI_PROCESSES \
+  --threads $UWSGI_THREADS \
+  --plugins python3 $UWSGI_EXTRA \
+  --protocol uwsgi \
+  --wsgi-disable-file-wrapper \
+  --uid $user_id \
+  --gid $group_id \
+  --master \
+  --chdir /srv/qwc_service \
+  --mount $SERVICE_MOUNTPOINT=server:app \
+  --manage-script-name


### PR DESCRIPTION
- Change ownership and permissions for `/etc/passwd` to add arbitrary user on start-up
- Change ownership and permissions for `/home` to create qwc directory on start-up
- Extend entrypoint script with user creation
- Install bash in Alpine image